### PR TITLE
Add React Native login test

### DIFF
--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import App from '../App';
+
+describe('App', () => {
+  it('logs in with valid credentials and shows note entry screen', () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(<App />);
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'doctor@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'secure123');
+
+    fireEvent.press(getByText('Login'));
+
+    expect(queryByText('Enter Patient Note')).toBeTruthy();
+    expect(getByText('Save Note')).toBeTruthy();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "doc-gpt-final",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@testing-library/react-native": "^12.1.3",
+    "@testing-library/jest-native": "^5.4.2",
+    "jest": "^29.5.0",
+    "react-test-renderer": "18.2.0",
+    "react": "18.2.0",
+    "react-native": "0.71.0"
+  },
+  "jest": {
+    "preset": "react-native",
+    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest for React Native
- add a basic login test using React Native Testing Library

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685acc882908832196ef0c479fc32e63